### PR TITLE
expand yamllint to scan all files in this repo except .venv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 updates:

--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore:
+    - .venv/
+
 rules:
     new-lines:
         type: platform  # use the newline settings of the platform run on

--- a/justfile
+++ b/justfile
@@ -6,8 +6,6 @@ format_checks := if fail_on_format_diff =="true" { "--check --diff" } else { "" 
 python_source := "./app/ ./src/ ./tests/ ./scripts/"
 pythonpath_value := "./app/:./src/:./scripts/"
 
-yaml_source := ".yamllint ./.github/workflows/"
-
 service_ip := "localhost"
 service_port := "8000"
 
@@ -42,7 +40,7 @@ pyright:
     @PYTHONPATH={{pythonpath_value}} uv run pyright {{python_source}}
 
 yamllint:
-    @uv run yamllint {{yaml_source}}
+    @uv run yamllint .
 
 dockerlint:
     @uv run hadolint Dockerfile


### PR DESCRIPTION
when I added .github/dependabot.yml, I found that yamllint wasn't scanning it. this addresses the warning in it as well as expands yamllint to scan all files in the repo except those in the .venv folder (as we don't control that)